### PR TITLE
Agrega loading al inicio de sesión y cambia respuesta filtro en administrar aseguradoras

### DIFF
--- a/src/app/administrar-polizas/componentes/polizas/polizas.component.html
+++ b/src/app/administrar-polizas/componentes/polizas/polizas.component.html
@@ -1377,7 +1377,7 @@
             </div>
             <div class="col-4 mx-3 mb-3">
                 <label>Cargar el Excel</label><span *ngIf="obligatorio" class="validacion">*</span>
-                <input type="file" class="form-control" title="Cargar Excel" accept=".xlsx">
+                <input type="file" class="form-control" title="Cargar Excel" accept=".xlsx"
                 formControlName="cargarExcel"
                 (change)="cargarArchivoXLSX($event,2)">
                 <app-validacion

--- a/src/app/administrar-polizas/componentes/polizas/polizas.component.ts
+++ b/src/app/administrar-polizas/componentes/polizas/polizas.component.ts
@@ -215,7 +215,7 @@ export class PolizasComponent implements OnInit {
   }
 
   guardarPolizas() {
-    console.log(this.formContractual);
+    //console.log(this.formContractual);
 
     if (this.formContractual.invalid) {//Valida formulario contarctual (Esté lleno)
       marcarFormularioComoSucio(this.formContractual)
@@ -393,6 +393,7 @@ export class PolizasComponent implements OnInit {
         })
         return;
       }
+      //Valida que los números de polizas contractual y extracontractua no sean iguales.
       if(this.formExtracontractual.controls['numeroPolizaE'].value == this.formContractual.controls['numeroPolizaC'].value){
         Swal.fire({
           icon: "error",

--- a/src/app/aseguradoras/aseguradora/aseguradora.component.html
+++ b/src/app/aseguradoras/aseguradora/aseguradora.component.html
@@ -42,7 +42,7 @@
                     </td>
                 </tr>
                 <tr *ngIf="aseguradoras.length === 0">
-                    <td colspan="6">No clients were found with the established filters.</td>
+                    <td colspan="6">No se encontraron aseguradoras con ese filtro.</td>
                 </tr>
             </tbody>
         </table>

--- a/src/app/autenticacion/componentes/inicio-sesion/inicio-sesion.component.ts
+++ b/src/app/autenticacion/componentes/inicio-sesion/inicio-sesion.component.ts
@@ -37,9 +37,16 @@ export class InicioSesionComponent implements OnInit {
       this.marcarFormularioComoSucio()
       return;
     }
+    Swal.fire({
+      icon: 'info',
+      allowOutsideClick: false,
+      text: 'Espere por favor...',
+    });
+    Swal.showLoading(null);
     this.servicioAutenticacion.iniciarSesion(this.formulario.controls['usuario'].value.toString(),this.formulario.controls['clave'].value,
     ).subscribe({
       next: (respuesta: IniciarSesionRespuesta) => {
+        Swal.close()
         this.servicioAutenticacion.guardarInformacionInicioSesion(respuesta.token,respuesta.rol,respuesta.usuario)
         if (respuesta.claveTemporal === true) {
           this.enrutador.navigateByUrl('/actualizar-contrasena')


### PR DESCRIPTION
Agrega un loading al iniciar sesión.
Corrige la respuesta del filtro de aseguradoras en el modulo administrar aseguradoras, cuando no encuentra resultados con ese filtro.