### PR TITLE
Verificación de fechas y cambios en modalidades

### DIFF
--- a/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.css
+++ b/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.css
@@ -5,3 +5,8 @@
 .texto-blanco{
     color: white;
 }
+
+.custom-modal-size {
+  max-width: 450; /* Ancho máximo del modal */
+  max-height: 600px; /* Altura máxima del modal */
+}

--- a/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.html
+++ b/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.html
@@ -3,7 +3,12 @@
         <h4 class="modal-title fs-14px  fw-bolder">Modalidades</h4>
         <button type="button" class="btn-close" aria-label="Close" (click)="closeModal()"></button>
     </div>
-    <div class="modal-body">
+    <div class="modal-body justify-content-center">
+      <div class="d-flex">
+        <span class="fs-14px">
+          <p>Por favor, registre las modalidades en las cuales se encuentra <br>actualmente habilitado (mixto, especial, pasajero por carretera)</p>
+        </span>
+      </div>
         <form >
             <!-- Modal MX -->
             <div *ngIf="modalidades[0].estado" class="clasificacion d-flex w-100 cursor-pointer fondo-desplegable-azul texto-blanco mb-3" (click)="alternarDesplegarMX()">
@@ -18,14 +23,14 @@
                     </div>
             </div>
             <div *ngIf="modalidades[0].estado" class="d-flex w-100 overflow-auto mb-3" [ngClass]="{'d-none': !desplegarMX, 'd-block': desplegarMX}">
-                <form [formGroup]="formMX">       
+                <form [formGroup]="formMX">
                     <div class="col-12">
                             <div class="row">
                                 <fieldset>
                                     <label for="numeroResolucionVigente" class="fw-semibold">
                                         Número de resolución vigente
                                     </label>
-                                    <input title="número resolución" type="number" class="form-control" 
+                                    <input title="número resolución" type="number" class="form-control"
                                     formControlName="numeroRMX">
                                     <span *ngIf="formMX.get('numeroRMX')?.hasError('maxLengthNumber')" class="validacion"> Deben ser máximo 18 digitos.</span>
                                     <span *ngIf="formMX.get('numeroRMX')?.hasError('negativo')" class="validacion"> No debe ser número negativo.</span>
@@ -52,9 +57,9 @@
                             <div class="row">
                                 <fieldset>
                                     <label for="PDFResolucionVigente" class="fw-semibold">
-                                        PDF con el documento vigente
+                                      Resolución (PDF, tamaño máximo 5MB)
                                     </label>
-                                    <input title="PDF resolución" type="file" class="form-control" 
+                                    <input title="PDF resolución" type="file" class="form-control"
                                     formControlName="PDFRMX" accept=".pdf" maxlength="1"
                                     (change)="cargarArchivoPDf($event,1)">
                                     <app-validacion
@@ -65,7 +70,7 @@
                                 </fieldset>
                             </div>
                     </div>
-                </form> 
+                </form>
             </div>
             <!--  Modal ES -->
             <div *ngIf="modalidades[1].estado" class="clasificacion d-flex w-100 cursor-pointer fondo-desplegable-azul texto-blanco mb-3" (click)="alternarDesplegarES()">
@@ -87,7 +92,7 @@
                                 <label for="numeroResolucionVigente" class="fw-semibold">
                                     Número de resolución vigente
                                 </label>
-                                <input title="número resolución" type="number" class="form-control" 
+                                <input title="número resolución" type="number" class="form-control"
                                 formControlName="numeroRES">
                                 <span *ngIf="formMX.get('numeroRES')?.hasError('maxLengthNumber')" class="validacion"> Deben ser máximo 18 digitos.</span>
                                 <span *ngIf="formMX.get('numeroRES')?.hasError('negativo')" class="validacion"> No debe ser número negativo.</span>
@@ -114,9 +119,9 @@
                         <div class="row">
                             <fieldset>
                                 <label for="PDFResolucionVigente" class="fw-semibold">
-                                    PDF con el documento vigente
+                                  Resolución vigente (PDF, tamaño máximo 5MB)
                                 </label>
-                                <input title="PDF resolución" type="file" class="form-control" 
+                                <input title="PDF resolución" type="file" class="form-control"
                                 formControlName="PDFRES" accept=".pdf" maxlength="1"
                                 (change)="cargarArchivoPDf($event,2)">
                                 <app-validacion
@@ -127,7 +132,7 @@
                             </fieldset>
                         </div>
                     </div>
-                </form> 
+                </form>
             </div>
              <!-- Modal PC  -->
             <div *ngIf="modalidades[2].estado" class="clasificacion d-flex w-100 cursor-pointer fondo-desplegable-azul texto-blanco mb-3" (click)="alternarDesplegarPC()">
@@ -149,7 +154,7 @@
                                 <label for="numeroResolucionVigente" class="fw-semibold">
                                     Número de resolución vigente
                                 </label>
-                                <input title="número resolución" type="number" class="form-control" 
+                                <input title="número resolución" type="number" class="form-control"
                                 formControlName="numeroRPC">
                                 <span *ngIf="formMX.get('numeroRPC')?.hasError('maxLengthNumber')" class="validacion"> Deben ser máximo 18 digitos.</span>
                                 <span *ngIf="formMX.get('numeroRPC')?.hasError('negativo')" class="validacion"> No debe ser número negativo.</span>
@@ -176,9 +181,9 @@
                         <div class="row">
                                 <fieldset>
                                 <label for="PDFResolucionVigente" class="fw-semibold">
-                                    PDF con el documento vigente
+                                  Resolución (PDF, tamaño máximo 5MB)
                                 </label>
-                                <input title="PDF resolución" type="file" class="form-control" 
+                                <input title="PDF resolución" type="file" class="form-control"
                                 formControlName="PDFRPC" accept=".pdf" maxlength="1"
                                 (change)="cargarArchivoPDf($event,3)">
                                 <app-validacion

--- a/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.ts
+++ b/src/app/administrar-polizas/componentes/polizas/modal/modal-capacidad/modal-capacidad.component.ts
@@ -11,6 +11,7 @@ import Swal from 'sweetalert2';
 import { maxLengthNumberValidator } from '../../validadores/maximo-validador';
 import { valorCeroValidar } from '../../validadores/cero-validacion';
 import { negativoValidar } from '../../validadores/negativo-verificar';
+import { tamanioValido } from '../../validadores/tamanio-archivo-validar';
 
 @Component({
   selector: 'app-modal-capacidad',
@@ -100,7 +101,8 @@ export class ModalCapacidadComponent implements OnInit {
 
   public abrir(): void {
     this.servicioModal.open(this.modal, {
-      size: 'lg'
+
+      windowClass: 'custom-modal-size'
     })
     //this.obtenerModalidades()
   }
@@ -242,6 +244,21 @@ export class ModalCapacidadComponent implements OnInit {
   cargarArchivoPDf(event: any, tipoModalidad: number) {
     const archivoSeleccionado = event.target.files[0];
     if (archivoSeleccionado) {
+      if(!tamanioValido(archivoSeleccionado,5)){
+        Swal.fire({
+          icon: 'error',
+          titleText: 'Excede el tamaño de archivo permitido',
+          text: 'El archivo debe pesar maximo 5MB',
+        });
+        if (tipoModalidad == 1) {
+          this.formMX.controls['PDFRMX'].setValue('')
+        } else if (tipoModalidad == 2) {
+          this.formES.controls['PDFRES'].setValue('')
+        } else if (tipoModalidad == 3) {
+          this.formPC.controls['PDFRPC'].setValue('')
+        }
+        return;
+      }
       Swal.fire({
         icon: 'info',
         allowOutsideClick: false,

--- a/src/app/administrar-polizas/componentes/polizas/polizas.component.html
+++ b/src/app/administrar-polizas/componentes/polizas/polizas.component.html
@@ -60,7 +60,8 @@
               class="validacion">*</span>
           </div>
           <div class="col-5">
-            <input formControlName="vigenciaPolizaInicioC" class="form-control" type="date" placeholder="Fecha inicial">
+            <input formControlName="vigenciaPolizaInicioC" class="form-control" type="date" placeholder="Fecha inicial"
+            (change)="fechasVerificar(1)">
             <app-validacion [validacion]="'required'" [texto]="'La fecha inicial de la vigencia es requerida.'"
               [control]="this.formContractual.controls['vigenciaPolizaInicioC']" />
           </div>
@@ -70,7 +71,8 @@
             <span class="fs-14px">Vigencia de la póliza: (Hasta: Final Vigencia)</span><span class="validacion">*</span>
           </div>
           <div class="col-5">
-            <input formControlName="vigenciaPolizaFinalC" class="form-control" type="date" placeholder="Fecha final">
+            <input formControlName="vigenciaPolizaFinalC" class="form-control" type="date" placeholder="Fecha final"
+            (change)="fechasVerificar(1)">
             <app-validacion [validacion]="'required'" [texto]="'La fecha final de la vigencia es requerida.'"
               [control]="this.formContractual.controls['vigenciaPolizaFinalC']" />
           </div>
@@ -742,7 +744,8 @@
             <span *ngIf="obligatorio" class="validacion">*</span>
           </div>
           <div class="col-5">
-            <input formControlName="vigenciaPolizaInicioE" class="form-control" type="date" placeholder="Fecha inicial">
+            <input formControlName="vigenciaPolizaInicioE" class="form-control" type="date" placeholder="Fecha inicial"
+            (change)="fechasVerificar(2)">
             <app-validacion [validacion]="'required'" [texto]="'La fecha inicial de la vigencia es requerida.'"
               [control]="this.formExtracontractual.controls['vigenciaPolizaInicioE']" />
           </div>
@@ -753,7 +756,8 @@
             <span *ngIf="obligatorio" class="validacion">*</span>
           </div>
           <div class="col-5">
-            <input formControlName="vigenciaPolizaFinalE" class="form-control" type="date" placeholder="Fecha final">
+            <input formControlName="vigenciaPolizaFinalE" class="form-control" type="date" placeholder="Fecha final"
+            (change)="fechasVerificar(2)">
             <app-validacion [validacion]="'required'" [texto]="'La fecha final de la vigencia es requerida.'"
               [control]="this.formExtracontractual.controls['vigenciaPolizaFinalE']" />
           </div>

--- a/src/app/administrar-polizas/componentes/polizas/polizas.component.ts
+++ b/src/app/administrar-polizas/componentes/polizas/polizas.component.ts
@@ -169,6 +169,34 @@ export class PolizasComponent implements OnInit {
     //this.deshabilitarFormularios()
     this.obtenerAseguradora()
   }
+  fechasVerificar(tipoPoliza: number){
+    const controlC = this.formContractual.controls
+    const controlE = this.formExtracontractual.controls
+
+    if(tipoPoliza == 1){
+      if(controlC['vigenciaPolizaInicioC'].value && controlC['vigenciaPolizaFinalC'].value){
+        if(controlC['vigenciaPolizaInicioC'].value > controlC['vigenciaPolizaFinalC'].value){
+          controlC['vigenciaPolizaInicioC'].setValue('')
+          controlC['vigenciaPolizaFinalC'].setValue('')
+          Swal.fire({
+            titleText:"El inicio de la vigencia no puede ser una fecha porterior al final de la vigencia.",
+            icon:"error"
+          })
+        }
+      }
+    }else if(tipoPoliza == 2){
+      if(controlE['vigenciaPolizaInicioE'].value && controlE['vigenciaPolizaFinalE'].value){
+        if(controlE['vigenciaPolizaInicioE'].value > controlE['vigenciaPolizaFinalE'].value){
+          controlE['vigenciaPolizaInicioE'].setValue('')
+          controlE['vigenciaPolizaFinalE'].setValue('')
+          Swal.fire({
+            titleText:"El inicio de la vigencia no puede ser una fecha porterior al final de la vigencia.",
+            icon:"error"
+          })
+        }
+      }
+    }
+  }
 
   respuestaNoResponsabilidad( tipoPoliza: number){
     const controlC = this.formContractual.controls


### PR DESCRIPTION
Verificación de fechas de vigencia en póliza:
- NO permite ingresar una fecha posterior en el campo “Desde: inicio vigencia” 
a la ingresada en el campo “Hasta: final vigencia”.

Cambios y verificaciones en Modalidades:
- Agrega descripción de bajo del título “Modalidades”
- Modifica texto en MX y PC por: Resolución (PDF, tamaño máximo 5MB)
- Modificar texto en ES por: Resolución vigente (PDF, tamaño máximo 5MB)
- Verifica que el tamaño de los archivos PDF cargados en modalidades no pase de 5MB